### PR TITLE
fixed header on mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           /></a>
           <a
             id="header-text"
-            class="text-white font-syne font-extrabold text-lg ml-[34px] lg:hidden"
+            class="text-white font-syne font-extrabold text-lg ml-[34px] block lg:hidden"
             href="#top"
           >
             ARRIORS

--- a/staff.html
+++ b/staff.html
@@ -24,7 +24,7 @@
         /></a>
         <a
           id="header-text"
-          class="text-white font-syne font-extrabold text-lg ml-[34px] lg:hidden"
+          class="text-white font-syne font-extrabold text-lg ml-[34px] block lg:hidden"
           href="#top"
         >
           ARRIORS


### PR DESCRIPTION
made the header text to be block by default. It was causing a bug on Safari where the text was misaligned if it wasn't set at block initially.